### PR TITLE
Minor refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,34 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "eqeqeq": "error",
+        "curly": "multi",
+        "no-unexpected-multiline": "error",
+        "no-case-declarations": "warn",
+        "no-console": [
+            "warn"
+        ],
+        "indent": [
+            "error",
+            2,
+            { "SwitchCase": 1 }
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "never"
+        ]
+    }
+};

--- a/scrape.js
+++ b/scrape.js
@@ -1,34 +1,34 @@
-const request = require("request");
-const cheerio = require("cheerio");
-const pretty = require("./pretty");
+const request = require("request")
+const cheerio = require("cheerio")
+const pretty = require("./pretty")
 
 const config = department =>
   ({
     method: "post",
     url: "http://appl101.lsu.edu/booklet2.nsf/68a84f901daef98386257b43006b778a?CreateDocument",
     body: `%25%25Surrogate_SemesterDesc=1&SemesterDesc=Spring+2017&%25%25Surrogate_Department=1&Department=${department}`
-  });
+  })
 
-const departments = [ "COMPUTER SCIENCE" ];
+const departments = [ "COMPUTER SCIENCE" ]
 
 const scrape = () => {
-  departments.forEach(department => request(config(department), onResponse));
-};
+  departments.forEach(department => request(config(department), onResponse))
+}
 
 const onResponse = (error, response, body) => {
   if (error) {
-    console.log("Error: " + error);
-    return;
+    console.log("Error: " + error)
+    return
   }
 
-  let $ = cheerio.load(body);
-  let pre = $("pre");
+  let $ = cheerio.load(body)
+  let pre = $("pre")
 
-  let lines = $(pre).html().split("\n").filter(str => str.trim().length > 0);
-  let courses = parseLines(lines);
+  let lines = $(pre).html().split("\n").filter(str => str.trim().length > 0)
+  let courses = parseLines(lines)
 
-  console.log(lines);
-};
+  console.log(lines)
+}
 
 const parseLines = lines => {
   const lineType = {
@@ -38,28 +38,27 @@ const parseLines = lines => {
     INTERVAL_GENERAL: Symbol(),
     INTERVAL_COMMENT: Symbol(),
     INTERVAL_EXTRA_TEACHER: Symbol(),
-  };
+  }
 
-  let currentLineType;
-  let sections = [];
-  let currentSection;
-  let currentSectionInfo = { comments: [] };
+  let currentLineType
+  let sections = []
+  let currentSection
+  let currentSectionInfo = { comments: [] }
 
   for (let i = 3; i < lines.length - 1; i++) {
-    let line = lines[i].replace(/&amp;/g, "&").replace(/&apos;/g, "'");
+    let line = lines[i].replace(/&amp/g, "&").replace(/&apos/g, "'")
 
-    const enrollmentAvailable = line.slice(0, 3).trim();
-    const enrollmentCount = line.slice(5, 9).trim();
-    const lineTrim = line.trim();
+    const enrollmentAvailable = line.slice(0, 3).trim()
+    const lineTrim = line.trim()
 
     // If enrollmentAvailable is not empty, it is either a number or "(F)", indicating
     // that a new section has begun.
     if (enrollmentAvailable !== "") {
       if (currentSection) {
-        sections.push(currentSection);
+        sections.push(currentSection)
       }
 
-      currentSection = { course: { comments: currentSectionInfo.comments } };
+      currentSection = { course: { comments: currentSectionInfo.comments } }
     }
 
     // DETERMINE LINE TYPE:
@@ -70,101 +69,104 @@ const parseLines = lines => {
     // Section Comment: A section-wide comment applying to all time intervals (Can have multiple)
     // Ex. '      ***   CSC  7080  ***       CROSS-LISTED WITH   EE 7720'
     if (lineTrim.startsWith("***")) {
-      currentLineType = lineType.SECTION_COMMENT;
+      currentLineType = lineType.SECTION_COMMENT
     }
 
     // Interval First: The start of a generalized interval. Things such as per-interval comments,
     // additional professors, or additional time intervals could follow.
     // Ex.  '  1    33  CSC  1351         1  COMP SCI II-MJRS       4.0   900-1020    T TH  0221 TUREAUD HALL                     BRANDT S'
     else if (enrollmentAvailable !== "") {
-      currentLineType = lineType.INTERVAL_FIRST;
+      currentLineType = lineType.INTERVAL_FIRST
     }
 
     // Extra Teacher: Indicates an extra teacher is being added to the most recently added time interval
     else if (line.slice(0, 116).trim() === "") {
-      currentLineType = lineType.INTERVAL_EXTRA_TEACHER;
+      currentLineType = lineType.INTERVAL_EXTRA_TEACHER
     }
 
     // Interval Comment: Indicates the start of an interval comment, not a section-wide comment. This comment
     // is to be added specifically to the most recently added interval.
     else if (lineTrim.startsWith("**") && !lineTrim.startsWith("***")) {
-      currentLineType = lineType.INTERVAL_COMMENT;
+      currentLineType = lineType.INTERVAL_COMMENT
     }
 
     // Lab Interval: Indicates the start of an interval with type lab.
     // Ex. '                     LAB                                     500-0750N     TH                                        BRANDT S',
     else if (lineTrim.startsWith("LAB")) {
-      currentLineType = lineType.INTERVAL_LAB;
+      currentLineType = lineType.INTERVAL_LAB
     }
 
     // General Additional Interval: This indicates the start of an additional time interval for this section. Some
     // sections have different times or buildings on certain days, therefore there can be multiple time intervals.
     // Ex. '                                                        1130-1220    T     0138 LOCKETT'
     else if (line.slice(0, 57).trim() === "" && line.includes("-")) {
-      currentLineType = lineType.INTERVAL_GENERAL;
+      currentLineType = lineType.INTERVAL_GENERAL
     }
 
     // PROCESS LINES:
     // Process the information of the current line contextually based on the
     // determined line type
 
-    let parsedLine = parseIntervalLine(line);
+    let parsedLine = parseIntervalLine(line)
 
     switch (currentLineType) {
       case lineType.SECTION_COMMENT:
-        currentSectionInfo.comments.push(line);
-        break;
+        currentSectionInfo.comments.push(line)
+        break
+
       case lineType.INTERVAL_FIRST:
-        setupCourse(currentSection, currentSectionInfo, parsedLine);
-        addInterval(currentSection, parsedLine);
-        break;
+        setupCourse(currentSection, currentSectionInfo, parsedLine)
+        addInterval(currentSection, parsedLine)
+        break
+
       case (lineType.INTERVAL_LAB):
       case (lineType.INTERVAL_GENERAL):
-        addInterval(currentSection, parsedLine);
-        break;
+        addInterval(currentSection, parsedLine)
+        break
+
       case lineType.INTERVAL_COMMENT:
-        processComment(currentSection, line);
-        break;
+        processComment(currentSection, line)
+        break
+
       case lineType.INTERVAL_EXTRA_TEACHER:
-        getCurrentInterval(currentSection).teachers.push(line.trim());
-        break;
+        getCurrentInterval(currentSection).teachers.push(line.trim())
+        break
     }
   }
 
-  console.log(pretty(sections));
-};
+  console.log(pretty(sections))
+}
 
 // A functional reducer-like function that takes comments, and the current interval,
 // and affects the state of the current interval based on the context of the comment.
 const processComment = (currentSection, line) => {
-  let interval = getCurrentInterval(currentSection);
+  let interval = getCurrentInterval(currentSection)
 
   if (line.includes("LAB WILL BE HELD IN ")) {
-    const comment = line.replace("**", "").trim();
-    let commentSections = comment.split(" ");
+    const comment = line.replace("**", "").trim()
+    let commentSections = comment.split(" ")
 
-    interval.comments.push(comment);
+    interval.comments.push(comment)
 
-    interval.location.building = commentSections[6];
-    interval.location.room = commentSections[5];
-    return;
+    interval.location.building = commentSections[6]
+    interval.location.room = commentSections[5]
+    return
   }
 
-  intervals.comments.push(line);
-};
+  interval.comments.push(line)
+}
 
 const getCurrentInterval = currentSection => {
-  return currentSection.section.intervals[currentSection.section.intervals.length -
-    1];
-};
+  return currentSection.section.intervals[currentSection.section.intervals.length - 1]
+}
 
 const setupCourse = (currentSection, currentSectionInfo, parsedLine) => {
-  let comments = currentSection.course.comments;
-  currentSection.course = parsedLine.course;
-  currentSection.course.comments = comments;
-  currentSectionInfo.comments = [];
-  currentSection.section = { enrollment: parsedLine.enrollment, intervals: [] };
-};
+  let comments = currentSection.course.comments
+  currentSection.course = parsedLine.course
+  currentSection.course.comments = comments
+  currentSectionInfo.comments = []
+  currentSection.section = { enrollment: parsedLine.enrollment, intervals: [] }
+}
 
 const addInterval = (currentSection, parsedLine) => {
   currentSection.section.intervals.push({
@@ -176,8 +178,8 @@ const addInterval = (currentSection, parsedLine) => {
     title: parsedLine.section.title,
     location: parsedLine.section.location,
     time: parsedLine.section.time
-  });
-};
+  })
+}
 
 //     ENRL   COURSE         SEC                          HR     TIME     DAYS                         SPECIAL
 //AVL  CNT   ABBR NUM  TYPE  NUM  COURSE TITLE            CR  BEGIN-END   MTWTFS ROOM  BUILDING        ENROLLMENT      INSTRUCTOR
@@ -186,55 +188,47 @@ const addInterval = (currentSection, parsedLine) => {
 // 53    47  CHE  2171         2  CHE FUND MAT EN BAL    3.0   930-1020   M W F  0204 TUREAUD HALL                     BENTON M
 //(F)     7  CHE  3104         1  ENGR MEASUREMENT LAB   3.0  1230-0120   M W    1221 PATRICK TAYLOR  CI-WRITTEN&SPOK  MELVIN E
 const parseIntervalLine = line => {
-  const enrollmentAvailable = Number(line.slice(0, 4).trim());
-  const enrollmentCount = Number(line.slice(4, 10).trim());
-  const enrollmentFull = enrollmentAvailable === "(F)";
+  const enrollmentAvailable = Number(line.slice(0, 4).trim())
+  const enrollmentCount = Number(line.slice(4, 10).trim())
+  const enrollmentFull = enrollmentAvailable === "(F)"
 
-  const courseAbbreviation = line.slice(10, 16).trim();
-  const courseNumber = line.slice(16, 21).trim();
-  const courseHours = line.slice(54, 59).trim();
+  const courseAbbreviation = line.slice(10, 16).trim()
+  const courseNumber = line.slice(16, 21).trim()
+  const courseHours = line.slice(54, 59).trim()
 
-  const sectionType = line.slice(21, 26).trim();
-  const isLab = sectionType.includes("LAB");
-  const sectionNumber = line.slice(26, 31).trim();
-  const sectionTitle = line.slice(31, 54).trim();
+  const sectionType = line.slice(21, 26).trim()
+  const isLab = sectionType.includes("LAB")
+  const sectionNumber = line.slice(26, 31).trim()
+  const sectionTitle = line.slice(31, 54).trim()
 
-  const timeInterval = line.slice(59, 70).trim();
-  const days = line.slice(72, 78);
-  let hasTime = timeInterval.includes("-");
-  let times = timeInterval.split("-");
-  let startTime = times[0];
-  let endTime = times[1];
-  let isNight = timeInterval.includes("N");
-  const dayArray = [];
+  const timeInterval = line.slice(59, 70).trim()
+  const days = line.slice(72, 78)
+  let hasTime = timeInterval.includes("-")
+  let times = timeInterval.split("-")
+  let startTime = times[0]
+  let endTime = times[1]
+  let isNight = timeInterval.includes("N")
+  const dayArray = []
 
   if (days.includes("H")) {
-    if (days.split("T").length - 1 === 2) {
-      Array.prototype.push.apply(dayArray, [ "TUESDAY", "THURSDAY" ]);
-    } else {
-      dayArray.push("THURSDAY");
-    }
+    if (days.split("T").length - 1 === 2) Array.prototype.push.apply(dayArray, [ "TUESDAY", "THURSDAY" ])
+    else dayArray.push("THURSDAY")
   } else {
-    if (days.includes("M"))
-      dayArray.push("MONDAY");
-    if (days.charAt(1) === "T")
-      dayArray.push("TUESDAY");
-    if (days.includes("W"))
-      dayArray.push("WEDNESDAY");
-    if (days.charAt(3) === "T")
-      dayArray.push("THURSDAY");
-    if (days.includes("F"))
-      dayArray.push("FRIDAY");
+    if (days.includes("M"))     dayArray.push("MONDAY")
+    if (days.charAt(1) === "T") dayArray.push("TUESDAY")
+    if (days.includes("W"))     dayArray.push("WEDNESDAY")
+    if (days.charAt(3) === "T") dayArray.push("THURSDAY")
+    if (days.includes("F"))     dayArray.push("FRIDAY")
   }
 
-  const roomNumber = line.slice(79, 84).trim();
-  const buildingName = line.slice(84, 99).trim();
+  const roomNumber = line.slice(79, 84).trim()
+  const buildingName = line.slice(84, 99).trim()
 
-  const specialEnrollment = line.slice(100, 116).trim();
-  const isWebBased = specialEnrollment.includes("WEB BASE");
-  const isComIntensive = specialEnrollment.includes("CI-WRITTEN&SPOK");
+  const specialEnrollment = line.slice(100, 116).trim()
+  const isWebBased = specialEnrollment.includes("WEB BASE")
+  const isComIntensive = specialEnrollment.includes("CI-WRITTEN&SPOK")
 
-  const teacher = line.slice(117, line.length - 1);
+  const teacher = line.slice(117, line.length - 1)
 
   return {
     enrollment: {
@@ -270,7 +264,7 @@ const parseIntervalLine = line => {
         days: dayArray
       }
     }
-  };
-};
+  }
+}
 
-module.exports = scrape;
+module.exports = scrape

--- a/scrape.js
+++ b/scrape.js
@@ -1,332 +1,275 @@
+const request = require("request");
+const cheerio = require("cheerio");
+const pretty = require("./pretty");
 
-const request = require("request")
-const cheerio = require("cheerio")
+const config = department =>
+  ({
+    method: "post",
+    url: "http://appl101.lsu.edu/booklet2.nsf/68a84f901daef98386257b43006b778a?CreateDocument",
+    body: `%25%25Surrogate_SemesterDesc=1&SemesterDesc=Spring+2017&%25%25Surrogate_Department=1&Department=${department}`
+  });
 
-const pretty = require("./pretty")
+const departments = [ "COMPUTER SCIENCE" ];
 
-const config = department => ({
-  method : "post",
-  url    : "http://appl101.lsu.edu/booklet2.nsf/68a84f901daef98386257b43006b778a?CreateDocument",
-  body   : `%25%25Surrogate_SemesterDesc=1&SemesterDesc=Spring+2017&%25%25Surrogate_Department=1&Department=${department}`
-})
+const scrape = () => {
+  departments.forEach(department => request(config(department), onResponse));
+};
 
-const departments = ["COMPUTER SCIENCE"]
-
-function scrape() {
-  departments.forEach(department => request(config(department), onResponse))
-}
-
-function onResponse(error, response, body) {
-
+const onResponse = (error, response, body) => {
   if (error) {
-
+    console.log("Error: " + error);
+    return;
   }
 
-  let $   = cheerio.load(body)
-  let pre = $("pre")
+  let $ = cheerio.load(body);
+  let pre = $("pre");
 
-  let lines   = $(pre).html().split("\n")
-  let courses = parseLines(lines)
+  let lines = $(pre).html().split("\n").filter(str => str.trim().length > 0);
+  let courses = parseLines(lines);
 
-  console.log(lines)
+  console.log(lines);
+};
 
-}
+const parseLines = lines => {
+  const lineType = {
+    SECTION_COMMENT: Symbol(),
+    INTERVAL_FIRST: Symbol(),
+    INTERVAL_LAB: Symbol(),
+    INTERVAL_GENERAL: Symbol(),
+    INTERVAL_COMMENT: Symbol(),
+    INTERVAL_EXTRA_TEACHER: Symbol(),
+  };
 
-function parseLines(lines) {
+  let currentLineType;
+  let sections = [];
+  let currentSection;
+  let currentSectionInfo = { comments: [] };
 
-  let courseDefault = {
-    enrollmentFull: false,
-    enrollmentAvailable: 0,
-    enrollmentCurrent: 0,
-    enrollmentTotal: 0,
-    creditHours: 0,
-    timeIntervals: [],
-    comments: []
-  }
+  for (let i = 3; i < lines.length - 1; i++) {
+    let line = lines[i].replace(/&amp;/g, "&").replace(/&apos;/g, "'");
 
-  let sections = []
-  let currentSection
-  let currentSectionInfo = {
-    comments: [],
-  }
-
-  const LINE_TYPE_SECTION_COMMENT        = Symbol()
-  const LINE_TYPE_INTERVAL_FIRST         = Symbol()
-  const LINE_TYPE_INTERVAL_LAB           = Symbol()
-  const LINE_TYPE_INTERVAL_GENERAL       = Symbol()
-  const LINE_TYPE_INTERVAL_COMMENT       = Symbol()
-  const LINE_TYPE_INTERVAL_EXTRA_TEACHER = Symbol()
-
-  let currentLineType
-
-  lines.forEach(function(line) {
-
-    // Conditions to reject the processing of a line
-
-    const isLineBlank   = line.trim() === ""
-    const isLineBullets = line.includes("---------------------------")
-    const isLineTitle   = line.trim().startsWith("ENRL") || line.trim().startsWith("AVL")
-
-    if (isLineBlank || isLineBullets || isLineTitle) {
-      return
-    }
-
-    const enrollmentAvailable = line.slice(0, 3).trim()
-    const enrollmentCount     = line.slice(5, 9).trim()
-    const lineTrim            = line.trim()
-
-    // Replace to ensure that all lines are the same max-width
-    line = line.replace(/&amp;/g, '&').replace(/&apos;/g, '\'')
-
-    // DETERMINE CURRENT SECTION:
-    // Determine if the criteria to switch to a new section is met
+    const enrollmentAvailable = line.slice(0, 3).trim();
+    const enrollmentCount = line.slice(5, 9).trim();
+    const lineTrim = line.trim();
 
     // If enrollmentAvailable is not empty, it is either a number or "(F)", indicating
     // that a new section has begun.
-
     if (enrollmentAvailable !== "") {
-
       if (currentSection) {
-        sections.push(currentSection)
+        sections.push(currentSection);
       }
 
-      currentSection = {
-        course: { comments: currentSectionInfo.comments }
-      }
+      currentSection = { course: { comments: currentSectionInfo.comments } };
     }
 
     // DETERMINE LINE TYPE:
     // Determine the type of the current line. Do not process any information
     // that alters state.
 
+
     // Section Comment: A section-wide comment applying to all time intervals (Can have multiple)
     // Ex. '      ***   CSC  7080  ***       CROSS-LISTED WITH   EE 7720'
     if (lineTrim.startsWith("***")) {
-      currentLineType = LINE_TYPE_SECTION_COMMENT
+      currentLineType = lineType.SECTION_COMMENT;
     }
 
     // Interval First: The start of a generalized interval. Things such as per-interval comments,
     // additional professors, or additional time intervals could follow.
     // Ex.  '  1    33  CSC  1351         1  COMP SCI II-MJRS       4.0   900-1020    T TH  0221 TUREAUD HALL                     BRANDT S'
-    if (enrollmentAvailable !== "") {
-      currentLineType = LINE_TYPE_INTERVAL_FIRST
+    else if (enrollmentAvailable !== "") {
+      currentLineType = lineType.INTERVAL_FIRST;
     }
 
     // Extra Teacher: Indicates an extra teacher is being added to the most recently added time interval
-    if (line.slice(0, 116).trim() === "") {
-      currentLineType = LINE_TYPE_INTERVAL_EXTRA_TEACHER
+    else if (line.slice(0, 116).trim() === "") {
+      currentLineType = lineType.INTERVAL_EXTRA_TEACHER;
     }
 
     // Interval Comment: Indicates the start of an interval comment, not a section-wide comment. This comment
     // is to be added specifically to the most recently added interval.
-    if (lineTrim.startsWith("**") && !lineTrim.startsWith("***")) {
-      currentLineType = LINE_TYPE_INTERVAL_COMMENT
+    else if (lineTrim.startsWith("**") && !lineTrim.startsWith("***")) {
+      currentLineType = lineType.INTERVAL_COMMENT;
     }
 
     // Lab Interval: Indicates the start of an interval with type lab.
     // Ex. '                     LAB                                     500-0750N     TH                                        BRANDT S',
-    if (lineTrim.startsWith("LAB")) {
-      currentLineType = LINE_TYPE_INTERVAL_LAB
+    else if (lineTrim.startsWith("LAB")) {
+      currentLineType = lineType.INTERVAL_LAB;
     }
 
     // General Additional Interval: This indicates the start of an additional time interval for this section. Some
     // sections have different times or buildings on certain days, therefore there can be multiple time intervals.
     // Ex. '                                                        1130-1220    T     0138 LOCKETT'
-    if (line.slice(0, 57).trim() === "" && line.includes("-")) {
-      currentLineType = LINE_TYPE_INTERVAL_GENERAL
+    else if (line.slice(0, 57).trim() === "" && line.includes("-")) {
+      currentLineType = lineType.INTERVAL_GENERAL;
     }
 
     // PROCESS LINES:
     // Process the information of the current line contextually based on the
     // determined line type
 
-    if (currentLineType === LINE_TYPE_SECTION_COMMENT) {
-      currentSectionInfo.comments.push(line)
+    let parsedLine = parseIntervalLine(line);
+
+    switch (currentLineType) {
+      case lineType.SECTION_COMMENT:
+        currentSectionInfo.comments.push(line);
+        break;
+      case lineType.INTERVAL_FIRST:
+        setupCourse(currentSection, currentSectionInfo, parsedLine);
+        addInterval(currentSection, parsedLine);
+        break;
+      case (lineType.INTERVAL_GENERAL || lineType.INTERVAL_LAB):
+        addInterval(currentSection, parsedLine);
+        break;
+      case lineType.INTERVAL_COMMENT:
+        processComment(currentSection, line);
+        break;
+      case lineType.INTERVAL_EXTRA_TEACHER:
+        getCurrentInterval(currentSection).teachers.push(line.trim());
+        break;
     }
+  }
 
-    if (currentLineType === LINE_TYPE_INTERVAL_FIRST) {
-      let parsedLine = parseIntervalLine(line)
-      setupCourse(currentSection, currentSectionInfo, parsedLine)
-      addInterval(currentSection, parsedLine)
-    }
-
-    if (
-      currentLineType === LINE_TYPE_INTERVAL_GENERAL ||
-      currentLineType === LINE_TYPE_INTERVAL_LAB
-    ) {
-      let parsedLine = parseIntervalLine(line)
-      addInterval(currentSection, parsedLine)
-    }
-
-    if (currentLineType === LINE_TYPE_INTERVAL_COMMENT) {
-      processComment(currentSection, line)
-    }
-
-    if (currentLineType === LINE_TYPE_INTERVAL_EXTRA_TEACHER) {
-      getCurrentInterval(currentSection).teachers.push(line.trim())
-    }
-
-  })
-
-  console.log(pretty(sections))
-
-}
+  console.log(pretty(sections));
+};
 
 // A functional reducer-like function that takes comments, and the current interval,
 // and affects the state of the current interval based on the context of the comment.
-function processComment(currentSection, line) {
-  let interval = getCurrentInterval(currentSection)
+const processComment = (currentSection, line) => {
+  let interval = getCurrentInterval(currentSection);
 
   if (line.includes("LAB WILL BE HELD IN ")) {
-    const comment = line.replace("**", "").trim()
-    let commentSections = comment.split(" ")
+    const comment = line.replace("**", "").trim();
+    let commentSections = comment.split(" ");
 
-    interval.comments.push(comment)
+    interval.comments.push(comment);
 
-    interval.location.building = commentSections[6]
-    interval.location.room     = commentSections[5]
-    return
+    interval.location.building = commentSections[6];
+    interval.location.room = commentSections[5];
+    return;
   }
 
-  intervals.comments.push(line)
-}
+  intervals.comments.push(line);
+};
 
-function getCurrentInterval(currentSection) {
-  return currentSection.section.intervals[currentSection.section.intervals.length - 1]
-}
+const getCurrentInterval = currentSection => {
+  return currentSection.section.intervals[currentSection.section.intervals.length -
+    1];
+};
 
-function setupCourse(currentSection, currentSectionInfo, parsedLine) {
-  let comments   = currentSection.course.comments
-  currentSection.course = parsedLine.course
-  currentSection.course.comments = comments
-  currentSectionInfo.comments = []
-  currentSection.section = {
-    enrollment: parsedLine.enrollment,
-    intervals: [ ]
-  }
-}
+const setupCourse = (currentSection, currentSectionInfo, parsedLine) => {
+  let comments = currentSection.course.comments;
+  currentSection.course = parsedLine.course;
+  currentSection.course.comments = comments;
+  currentSectionInfo.comments = [];
+  currentSection.section = { enrollment: parsedLine.enrollment, intervals: [] };
+};
 
-function addInterval(currentSection, parsedLine) {
+const addInterval = (currentSection, parsedLine) => {
   currentSection.section.intervals.push({
-    teachers: [parsedLine.section.teacher],
+    teachers: [ parsedLine.section.teacher ],
     comments: [],
     type: parsedLine.section.type,
     isLab: parsedLine.section.isLab,
     number: parsedLine.section.number,
     title: parsedLine.section.title,
     location: parsedLine.section.location,
-    time: parsedLine.section.time,
-  })
-}
-  
+    time: parsedLine.section.time
+  });
+};
+
 //     ENRL   COURSE         SEC                          HR     TIME     DAYS                         SPECIAL
 //AVL  CNT   ABBR NUM  TYPE  NUM  COURSE TITLE            CR  BEGIN-END   MTWTFS ROOM  BUILDING        ENROLLMENT      INSTRUCTOR
 //----------------------------------------------------------------------------------------------------------------------------------
-//   4     10    16   21   26   31                     54   59         70       79   84             99               118           132       
+//   4     10    16   21   26   31                     54   59         70       79   84             99               118           132
 // 53    47  CHE  2171         2  CHE FUND MAT EN BAL    3.0   930-1020   M W F  0204 TUREAUD HALL                     BENTON M
 //(F)     7  CHE  3104         1  ENGR MEASUREMENT LAB   3.0  1230-0120   M W    1221 PATRICK TAYLOR  CI-WRITTEN&SPOK  MELVIN E
-function parseIntervalLine(line) {
+const parseIntervalLine = line => {
+  const enrollmentAvailable = Number(line.slice(0, 4).trim());
+  const enrollmentCount = Number(line.slice(4, 10).trim());
+  const enrollmentFull = enrollmentAvailable === "(F)";
 
-  const enrollmentAvailable = line.slice(0, 4).trim()
-  const enrollmentCount     = line.slice(4, 10).trim()
-  let enrollmentFull        = enrollmentAvailable === "(F)"
+  const courseAbbreviation = line.slice(10, 16).trim();
+  const courseNumber = line.slice(16, 21).trim();
+  const courseHours = line.slice(54, 59).trim();
 
-  const courseAbbreviation = line.slice(10, 16).trim()
-  const courseNumber       = line.slice(16, 21).trim()
-  const courseHours        = line.slice(54, 59).trim()
-  
-  const sectionType   = line.slice(21, 26).trim()
-  const isLab         = sectionType.includes("LAB")
-  const sectionNumber = line.slice(26, 31).trim()
-  const sectionTitle  = line.slice(31, 54).trim()
+  const sectionType = line.slice(21, 26).trim();
+  const isLab = sectionType.includes("LAB");
+  const sectionNumber = line.slice(26, 31).trim();
+  const sectionTitle = line.slice(31, 54).trim();
 
-  const timeInterval = line.slice(59, 70).trim()
-  const days         = line.slice(72, 78)
-  let hasTime        = timeInterval.includes("-")
-  let times          = timeInterval.split("-")
-  let startTime      = times[0]
-  let endTime        = times[1]
-  let isNight        = timeInterval.includes("N")
-  const dayArray     = []
+  const timeInterval = line.slice(59, 70).trim();
+  const days = line.slice(72, 78);
+  let hasTime = timeInterval.includes("-");
+  let times = timeInterval.split("-");
+  let startTime = times[0];
+  let endTime = times[1];
+  let isNight = timeInterval.includes("N");
+  const dayArray = [];
 
   if (days.includes("H")) {
-    if (findOccurences(days, "T") === 2) Array.prototype.push.apply(dayArray, ["TUESDAY", "THURSDAY"])
-    else dayArray.push("THURSDAY")
-  }
-
-  else {
-    if (days.includes("M")) dayArray.push("MONDAY")
-    if (days.charAt(1) === "T") dayArray.push("TUESDAY")
-    if (days.includes("W")) dayArray.push("WEDNESDAY")
-    if (days.charAt(3) === "T") dayArray.push("THURSDAY")
-    if (days.includes("F")) dayArray.push("FRIDAY") 
-  }
-
-  const roomNumber   = line.slice(79, 84).trim()
-  const buildingName = line.slice(84, 99).trim()
-
-  const specialEnrollment = line.slice(100, 116).trim()
-  const isWebBased        = specialEnrollment.includes("WEB BASE")
-  const isComIntensive    = specialEnrollment.includes("CI-WRITTEN&SPOK")
-
-  const teacher = line.slice(117, line.length - 1)
-
-  const r = {
-
-    enrollment: {
-      available : enrollmentFull ? 0 : Number(enrollmentAvailable),
-      current   : Number(enrollmentCount),
-      total     : enrollmentFull ? Number(enrollmentCount) : Number(enrollmentCount) + Number(enrollmentAvailable),
-      isFull    : enrollmentFull,
-    },
-
-    course: {
-      abbreviation : courseAbbreviation,
-      number       : courseNumber,
-      hours        : courseHours,
-
-      special      : {
-        text           : specialEnrollment,
-        isComIntensive : isComIntensive,
-        isWebBased     : isWebBased
-      }
-    },
-
-    section: {
-      type    : sectionType,
-      isLab   : isLab,
-      number  : sectionNumber,
-      title   : sectionTitle,
-      teacher : teacher,
-
-      location: {
-        building : buildingName,
-        room     : roomNumber,
-      },
-
-      time: {
-        start   : startTime,
-        end     : endTime,
-        hasTime : hasTime,
-        isNight : isNight,
-        days    : dayArray,
-      }
-
+    if (days.split("T").length - 1 === 2) {
+      Array.prototype.push.apply(dayArray, [ "TUESDAY", "THURSDAY" ]);
+    } else {
+      dayArray.push("THURSDAY");
     }
-
+  } else {
+    if (days.includes("M"))
+      dayArray.push("MONDAY");
+    if (days.charAt(1) === "T")
+      dayArray.push("TUESDAY");
+    if (days.includes("W"))
+      dayArray.push("WEDNESDAY");
+    if (days.charAt(3) === "T")
+      dayArray.push("THURSDAY");
+    if (days.includes("F"))
+      dayArray.push("FRIDAY");
   }
 
-  //console.log("\n" + pretty(r) + "\n")
+  const roomNumber = line.slice(79, 84).trim();
+  const buildingName = line.slice(84, 99).trim();
 
-  return r
-}
+  const specialEnrollment = line.slice(100, 116).trim();
+  const isWebBased = specialEnrollment.includes("WEB BASE");
+  const isComIntensive = specialEnrollment.includes("CI-WRITTEN&SPOK");
 
-function findOccurences(string, ofChar){
-  return string.split(ofChar).length - 1;
-}
+  const teacher = line.slice(117, line.length - 1);
 
-function isNumber(num) {
-  return !isNaN(num)
-}
+  return {
+    enrollment: {
+      available: enrollmentFull ? 0 : enrollmentAvailable,
+      current: enrollmentCount,
+      total: enrollmentFull
+        ? enrollmentCount
+        : enrollmentCount + enrollmentAvailable,
+      isFull: enrollmentFull
+    },
+    course: {
+      abbreviation: courseAbbreviation,
+      number: courseNumber,
+      hours: courseHours,
+      special: {
+        text: specialEnrollment,
+        isComIntensive,
+        isWebBased,
+      }
+    },
+    section: {
+      type: sectionType,
+      isLab: isLab,
+      number: sectionNumber,
+      title: sectionTitle,
+      teacher: teacher,
+      location: { building: buildingName, room: roomNumber },
+      time: {
+        start: startTime,
+        end: endTime,
+        hasTime,
+        isNight,
+        days: dayArray
+      }
+    }
+  };
+};
 
-module.exports = scrape
+module.exports = scrape;

--- a/scrape.js
+++ b/scrape.js
@@ -118,7 +118,8 @@ const parseLines = lines => {
         setupCourse(currentSection, currentSectionInfo, parsedLine);
         addInterval(currentSection, parsedLine);
         break;
-      case (lineType.INTERVAL_GENERAL || lineType.INTERVAL_LAB):
+      case (lineType.INTERVAL_LAB):
+      case (lineType.INTERVAL_GENERAL):
         addInterval(currentSection, parsedLine);
         break;
       case lineType.INTERVAL_COMMENT:


### PR DESCRIPTION
Converted all methods to ES6 arrow syntax for consistent styling all the way
through the app. Since we aren't using `this` anywhere, there is no problem
with the bindings.

Add “error handling” to onResponse method. Just printed and returned the error
passed to it.

Modify lines array by adding a filter for trimmed strings being greater than 0
length. This removes the need to process these lines.

Turned `lineType`s into “enum” with an object. This makes it more obvious this
is an “enum” type and it sections those variables.

Turned the `forEach` loop in the `parseLines` function into a for loop. This
was done because the original `forEach` loop needed special checks on each
line to determine its validity as good information. With the previous change
of filtering the lines array by line length in addition to this change, we
can be confident that every line that is read by this loop is usable
information. The reason for starting the iteration at 3 is because the first
two lines are table headers (index 0 and 1) and the third line is a splitter
(index 2).

With the above change, the line still needed special characters replaced. This
is done here with regex replacement of `&amp;` and `&apos;` to `&` and `’` to
make sure all lines are the same length - these characters were being escaped
into their HTML entities which was throwing off the parsing.

If statements for determining `lineType` was turned into an if / else branch.
This is because a line cannot be more than one lineType, and if the lineType
has been found, another will not take its place. By using an if / else branch,
the script does not have to check each individual if statement anymore. Once it
finds the answer, it can continue to the next steps.

The last if / else branch for determining what to do with `lineType` enum has
been turned into a switch statement.

The resulting object from `parseIntervalLine` has had some attributes
implicitly defined. Example: `hasTime:  hasTime,` was turned into `hasTime,`.

Prettier was ran. I'm not sure this should become a habit yet because it seems
to still be pretty buggy and doesn't like some styling that is in this file.