### PR TITLE
Escape department names for POST

### DIFF
--- a/scrapers/scrapeDepartmentCourses.js
+++ b/scrapers/scrapeDepartmentCourses.js
@@ -24,7 +24,7 @@ const scrape = departments => {
 
 const escapeDepartment = department =>
   department
-    .replace(/%s/g, "+")
+    .replace(/\s+/g, "+")
     .replace(/&/g, "%26")
     .replace(/\'/g, "%27")
     .replace(/,/g, "%2C");


### PR DESCRIPTION
This commit escapes the department names for the POST to get the department
courses.

This was causing some departments to return no courses even when there was.

closes #12